### PR TITLE
Refs [TASK] [36701] Xử lý thao tác người dùng với hình ảnh

### DIFF
--- a/app/src/main/java/com/sun/unsplash_02/screen/search/SearchFragment.kt
+++ b/app/src/main/java/com/sun/unsplash_02/screen/search/SearchFragment.kt
@@ -42,7 +42,10 @@ class SearchFragment : BaseFragment(), SearchContract.View {
         view.toolbarSearch.run {
             setNavigationIcon(R.drawable.ic_arrow_back)
             setNavigationOnClickListener {
-                activity?.supportFragmentManager?.popBackStack()
+                activity?.let {
+                    it.supportFragmentManager?.popBackStack()
+                    view.editTextSearch.hideKeyboard(it)
+                }
             }
         }
         view.editTextSearch.setOnFocusChangeListener { _, hasFocus ->

--- a/app/src/main/java/com/sun/unsplash_02/utils/EdittextExt.kt
+++ b/app/src/main/java/com/sun/unsplash_02/utils/EdittextExt.kt
@@ -8,7 +8,7 @@ fun EditText.showKeyboard(activity: Activity) {
     val inputMethodManager =
         activity.getSystemService(Activity.INPUT_METHOD_SERVICE) as InputMethodManager
     requestFocus()
-    inputMethodManager.showSoftInput(this, 0)
+    inputMethodManager.toggleSoftInput(InputMethodManager.SHOW_FORCED, 0)
 }
 
 fun EditText.hideKeyboard(activity: Activity) {

--- a/app/src/main/java/com/sun/unsplash_02/utils/customview/ZoomImageView.kt
+++ b/app/src/main/java/com/sun/unsplash_02/utils/customview/ZoomImageView.kt
@@ -1,10 +1,15 @@
 package com.sun.unsplash_02.utils.customview
 
 import android.content.Context
+import android.graphics.Matrix
+import android.graphics.PointF
 import android.util.AttributeSet
 import android.view.GestureDetector
 import android.view.MotionEvent
+import android.view.ScaleGestureDetector
 import androidx.appcompat.widget.AppCompatImageView
+import kotlin.math.abs
+import kotlin.math.min
 
 class ZoomImageView @JvmOverloads constructor(
     contextImage: Context,
@@ -12,6 +17,76 @@ class ZoomImageView @JvmOverloads constructor(
     defStyleAttr: Int = 0
 ) : AppCompatImageView(contextImage, attrs, defStyleAttr), GestureDetector.OnGestureListener,
     GestureDetector.OnDoubleTapListener {
+
+    private var matrixImage: Matrix
+    private var mode = NONE
+    private var last: PointF
+    private var start: PointF
+    private var matrixArray: FloatArray
+    private var viewWidth = 0f
+    private var viewHeight = 0f
+    private var origWidth = 0f
+    private var origHeight = 0f
+    private var oldMeasureWidth = 0f
+    private var oldMeasureHeight = 0f
+    private var minScale = 1f
+    private var maxScale = 3f
+    private var saveScale = 1f
+    private var scaleGestureDetector: ScaleGestureDetector
+    private var gestureDetector: GestureDetector
+
+    init {
+        super.setClickable(true)
+        last = PointF()
+        start = PointF()
+        GestureDetector(context, this).apply {
+            setOnDoubleTapListener(this@ZoomImageView)
+            gestureDetector = this
+        }
+        scaleGestureDetector = ScaleGestureDetector(context, ScaleListener())
+        matrixImage = Matrix()
+        matrixArray = FloatArray(9)
+        imageMatrix = matrixImage
+        scaleType = ScaleType.MATRIX
+        setOnTouchListener { _, event ->
+            scaleGestureDetector.onTouchEvent(event)
+            gestureDetector.onTouchEvent(event)
+            val currentPointF = PointF(event.x, event.y)
+            when (event.action) {
+                MotionEvent.ACTION_DOWN -> {
+                    last.set(currentPointF)
+                    start.set(last)
+                    mode = DRAG
+                }
+                MotionEvent.ACTION_MOVE -> {
+                    if (mode == DRAG) {
+                        val deltaX = currentPointF.x - last.x
+                        val deltaY = currentPointF.y - last.y
+                        val fixTransX = getFixDragTrans(deltaX, viewWidth, origWidth * saveScale)
+                        val fixTransY = getFixDragTrans(deltaY, viewHeight, origHeight * saveScale)
+                        matrixImage.postTranslate(fixTransX, fixTransY)
+                        fixTrans()
+                        last.set(currentPointF.x, currentPointF.y)
+                    }
+                }
+                MotionEvent.ACTION_UP -> {
+                    mode = NONE
+                    val xDiff = abs(currentPointF.x - start.x)
+                    val yDiff = abs(currentPointF.y - start.y)
+                    if (xDiff < CLICK && yDiff < CLICK) {
+                        performClick()
+                    }
+                }
+                MotionEvent.ACTION_POINTER_UP -> {
+                    mode = NONE
+                }
+                else -> Unit
+            }
+            imageMatrix = matrixImage
+            invalidate()
+            true
+        }
+    }
 
     override fun onDown(e: MotionEvent?) = false
 
@@ -37,12 +112,128 @@ class ZoomImageView @JvmOverloads constructor(
 
     override fun onSingleTapConfirmed(e: MotionEvent?) = false
 
-    override fun onDoubleTap(e: MotionEvent?) = false
+    override fun onDoubleTap(e: MotionEvent?): Boolean {
+        val origScale = saveScale
+        val scaleFactor: Float
+        if (saveScale == maxScale) {
+            saveScale = minScale
+            scaleFactor = minScale / origScale
+        } else {
+            saveScale = maxScale
+            scaleFactor = maxScale / origScale
+        }
+        matrixImage.postScale(scaleFactor, scaleFactor, 0f, 0f)
+        fixTrans()
+        return false
+    }
 
     override fun onDoubleTapEvent(e: MotionEvent?) = false
 
     override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
         super.onMeasure(widthMeasureSpec, heightMeasureSpec)
+        viewWidth = MeasureSpec.getSize(widthMeasureSpec).toFloat()
+        viewHeight = MeasureSpec.getSize(heightMeasureSpec).toFloat()
+        if (oldMeasureHeight == viewHeight || oldMeasureWidth == viewWidth
+            || viewHeight == 0f || viewWidth == 0f
+        ) return
+        oldMeasureHeight = viewHeight
+        oldMeasureWidth = viewWidth
+        if (saveScale == 1f) {
+            drawable?.let {
+                if (it.intrinsicWidth == 0 || it.intrinsicHeight == 0) {
+                    return
+                }
+                val scale: Float
+                val bmWidth = it.intrinsicWidth
+                val bmHeight = it.intrinsicHeight
+                val scaleX = viewWidth / bmWidth
+                val scaleY = viewHeight / bmHeight
+                scale = min(scaleX, scaleY)
+                matrixImage.setScale(scale, scale)
+                var redundantYSpace = (viewHeight - scale * bmHeight.toFloat())
+                var redundantXSpace = (viewWidth - scale * bmWidth.toFloat())
+                redundantYSpace /= 2.toFloat()
+                redundantXSpace /= 2.toFloat()
+                matrixImage.postTranslate(redundantXSpace, redundantYSpace)
+                origWidth = viewWidth - 2 * redundantXSpace
+                origHeight = viewHeight - 2 * redundantYSpace
+                imageMatrix = matrixImage
+            }
+            fixTrans()
+        }
+    }
+
+    private fun fixTrans() {
+        matrixImage.getValues(matrixArray)
+        val transX = matrixArray[Matrix.MTRANS_X]
+        val transY = matrixArray[Matrix.MTRANS_Y]
+        val fixTransX = getFixTrans(transX, viewWidth, origWidth * saveScale)
+        val fixTransY = getFixTrans(transY, viewHeight, origHeight * saveScale)
+        if (fixTransX != 0f || fixTransY != 0f) {
+            matrixImage.postTranslate(fixTransX, fixTransY)
+        }
+    }
+
+    private fun getFixTrans(trans: Float, viewSize: Float, contentSize: Float): Float {
+        val minTrans: Float
+        val maxTrans: Float
+        if (contentSize <= viewSize) {
+            minTrans = 0f
+            maxTrans = viewSize - contentSize
+        } else {
+            minTrans = viewSize - contentSize
+            maxTrans = 0f
+        }
+        if (trans < minTrans) return -trans + minTrans
+        return if (trans > maxTrans) -trans + maxTrans else 0f
+    }
+
+    private fun getFixDragTrans(delta: Float, viewSize: Float, contentSize: Float): Float {
+        if (contentSize <= viewSize) {
+            return 0f
+        }
+        return delta
+    }
+
+    inner class ScaleListener : ScaleGestureDetector.SimpleOnScaleGestureListener() {
+        override fun onScaleBegin(detector: ScaleGestureDetector?): Boolean {
+            mode = ZOOM
+            return true
+        }
+
+        override fun onScale(detector: ScaleGestureDetector): Boolean {
+            var scaleFactor = detector.scaleFactor
+            val origScale = saveScale
+            saveScale *= scaleFactor
+            when {
+                saveScale > maxScale -> {
+                    saveScale = maxScale
+                    scaleFactor = maxScale / origScale
+                }
+                saveScale < minScale -> {
+                    saveScale = minScale
+                    scaleFactor = minScale / origScale
+                }
+                else -> Unit
+            }
+            when {
+                origWidth * saveScale <= viewWidth
+                        || origHeight * saveScale <= viewHeight -> {
+                    matrixImage.postScale(
+                        scaleFactor, scaleFactor, 0f,
+                        0f
+                    )
+                }
+                else -> {
+                    matrixImage.postScale(
+                        scaleFactor, scaleFactor,
+                        detector.focusX, detector.focusY
+                    )
+                }
+            }
+            fixTrans()
+            return true
+        }
     }
 
     companion object {

--- a/app/src/main/res/layout/fragment_detail.xml
+++ b/app/src/main/res/layout/fragment_detail.xml
@@ -35,7 +35,6 @@
         app:layout_constraintStart_toStartOf="@id/imageCrop"
         app:layout_constraintTop_toBottomOf="@id/imageCrop" />
 
-
     <ImageView
         android:id="@+id/imageFilter"
         android:layout_width="wrap_content"
@@ -72,7 +71,6 @@
         app:layout_constraintStart_toStartOf="@id/imageDraw"
         app:layout_constraintTop_toBottomOf="@id/imageDraw" />
 
-
     <ImageView
         android:id="@+id/imageBrightness"
         android:layout_width="wrap_content"
@@ -90,7 +88,6 @@
         app:layout_constraintEnd_toEndOf="@id/imageBrightness"
         app:layout_constraintStart_toStartOf="@id/imageBrightness"
         app:layout_constraintTop_toBottomOf="@id/imageBrightness" />
-
 
     <ImageView
         android:id="@+id/imageIcon"


### PR DESCRIPTION
## Related Tickets
- [#Task 36701: Xử lý thao tác người dùng với hình ảnh](https://edu-redmine.sun-asterisk.vn/issues/36701)
## WHAT
- Xử lý thao tác người dùng với hình ảnh
## Evidence (Screenshot or Video)
<img width="399" alt="Screen Shot 2021-06-03 at 08 51 21" src="https://user-images.githubusercontent.com/83062073/120575108-ab919180-c44a-11eb-8590-fe303727b764.png">
<img width="399" alt="Screen Shot 2021-06-03 at 08 51 38" src="https://user-images.githubusercontent.com/83062073/120575125-b2200900-c44a-11eb-9130-9d703c5b1583.png">

## Review Checklist

Category | View Point | Description | Self review | Reviewer2 (name)
--- | --- | --- | --- | ---
Conventions | Sun* coding conventions | https://github.com/framgia/coding-standards/tree/master/eng/android |<li>- [ ] yes</li>|<li>- [ ] yes</li>
Conventions | Kotlin coding conventions | https://kotlinlang.org/docs/coding-conventions.html |<li>- [ ] yes</li>|<li>- [ ] yes</li>
Redmine | Sun* Redmine working process  | https://github.com/framgia/Training-Guideline/blob/master/WorkingProcess/redmine/redmine.md |<li>- [ ] yes</li>|<li>- [ ] yes</li>

## Notes (Optional)
*(Impacted Areas in Application(List features, api, models or services that this PR will affect))*

*(List gem, library third party add new)*

*(Other notes)*